### PR TITLE
[ENHANCEMENT] Separate Base URL and API URL

### DIFF
--- a/lib/zuora-rest.rb
+++ b/lib/zuora-rest.rb
@@ -34,6 +34,14 @@ module Zuora
 
     def base_url
       if production_mode
+        "https://rest.zuora.com"
+      else
+        "https://rest.apisandbox.zuora.com"
+      end
+    end
+
+    def api_url
+      if production_mode
         "https://rest.zuora.com/v1/"
       else
         "https://rest.apisandbox.zuora.com/v1/"

--- a/lib/zuora/action.rb
+++ b/lib/zuora/action.rb
@@ -21,7 +21,7 @@ module Zuora
       end
 
       def resource_endpoint
-        [Zuora.base_url, "action"].join
+        [Zuora.api_url, "action"].join
       end
     end
   end

--- a/lib/zuora/resource.rb
+++ b/lib/zuora/resource.rb
@@ -4,7 +4,7 @@ module Zuora
 
     class << self
       def base_resource_url
-        [Zuora.base_url, resource_endpoint].join
+        [Zuora.api_url, resource_endpoint].join
       end
 
       def resource_endpoint
@@ -16,7 +16,7 @@ module Zuora
         _, *namespaces, resource_singular = self.name.underscore.dasherize.split("/")
         segments = ['object', resource_singular]
         segments << model_id if model_id
-        [Zuora.base_url, segments.join('/')].join
+        [Zuora.api_url, segments.join('/')].join
       end
     end
   end


### PR DESCRIPTION
Zuora Invoice sometimes doesn't send the domain in `pdf_url`, what they send is `/v1/files/<file id>`, we need to get the base URL without the version to append to that URL.