### PR TITLE
Handle Action::Query Response

### DIFF
--- a/lib/zuora/action.rb
+++ b/lib/zuora/action.rb
@@ -3,10 +3,15 @@ require "zuora/error_handler/bulk_action"
 module Zuora
   class Action < Resource
     class << self
-      [:query, :create].each do |action_name|
-        define_method(action_name) do |body|
-          Zuora.request(:post, action_base_url(action_name), {body: body.to_json})
-        end
+      def create(body)
+        Zuora.request(:post, action_base_url(:create), {body: body.to_json})
+      end
+
+      def query(body)
+        Zuora.request(:post, action_base_url(:query), {
+          body: body.to_json,
+          error_handler: Zuora::ErrorHandler::BulkAction
+        })
       end
 
       def amend(body)

--- a/lib/zuora/error_handler/bulk_action.rb
+++ b/lib/zuora/error_handler/bulk_action.rb
@@ -3,6 +3,7 @@ module Zuora
     class BulkAction
       def self.handle_response(response)
         return generate_action_responses(response["results"]) if response["results"]
+        return generate_action_responses(response["records"]) if response["records"]
 
         if response["message"]
           raise Zuora::ErrorHandler::APIError.new(response["message"])


### PR DESCRIPTION
We only handled `results` key in the BulkAction error handler, but `Action::query` endpoint use `records` instead of `results`.

![Screen Shot 2019-04-24 at 2 06 21 PM](https://user-images.githubusercontent.com/12812070/56636050-2bf53e00-669a-11e9-949b-519e225501fb.png)
