### PR TITLE
Support Action.create Response in ErrorHandler

### DIFF
--- a/lib/zuora/action.rb
+++ b/lib/zuora/action.rb
@@ -1,10 +1,14 @@
 require "zuora/error_handler/bulk_action"
+require "zuora/error_handler/bulk_create"
 
 module Zuora
   class Action < Resource
     class << self
       def create(body)
-        Zuora.request(:post, action_base_url(:create), {body: body.to_json})
+        Zuora.request(:post, action_base_url(:create), {
+          body: body.to_json,
+          error_handler: Zuora::ErrorHandler::BulkCreate
+        })
       end
 
       def query(body)

--- a/lib/zuora/error_handler/bulk_create.rb
+++ b/lib/zuora/error_handler/bulk_create.rb
@@ -1,0 +1,9 @@
+module Zuora
+  module ErrorHandler
+    class BulkCreate < BulkAction
+      def self.handle_response(response)
+        return generate_action_responses(response)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This endpoint has different response than the one handled in `ErrorHandler::BulkAction`
![Screen Shot 2019-04-24 at 5 43 58 PM](https://user-images.githubusercontent.com/12812070/56649929-a03eda00-66b8-11e9-81a3-8fe85c826100.png)
