### PR TITLE
[FEATURE] Data query API and Bearer token support

### DIFF
--- a/lib/zuora-rest.rb
+++ b/lib/zuora-rest.rb
@@ -27,6 +27,8 @@ require "zuora/payment_methods/credit_card"
 require "zuora/catalog/product"
 require "zuora/charge_revenue_summaries/subscription_charge"
 require "zuora/rsa_signature"
+require "zuora/access_token"
+require "zuora/data_query"
 
 module Zuora
   class << self

--- a/lib/zuora/access_token.rb
+++ b/lib/zuora/access_token.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Zuora
+  class AccessToken
+    include HTTParty
+    
+    headers 'Content-Type' => 'application/x-www-form-urlencoded'
+    headers 'User-Agent' => "zuora-rest/#{Zuora::VERSION}"
+
+    class << self
+      def generate
+        response = HTTParty.post(oauth_token_url, body: request_body)
+        raise Zuora::ErrorHandler::APIError, response unless response.code == 200
+
+        response['access_token']
+      end
+
+    private
+
+      def request_body
+        {
+          'client_id' => ENV['ZUORA_CLIENT_ID'],
+          'client_secret' => ENV['ZUORA_CLIENT_SECRET'],
+          'grant_type' => 'client_credentials'
+        }
+      end
+
+      def oauth_token_url
+        "#{Zuora.base_url}/oauth/token"
+      end
+    end
+  end
+end

--- a/lib/zuora/data_query.rb
+++ b/lib/zuora/data_query.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Zuora
+  class DataQuery
+
+    class << self
+      def schedule_job(params)
+        response = Zuora::HttpClient.post(query_job_url, body: default_params.merge(params).to_json, headers: auth_header)
+        handle_response(response)
+      end
+
+      def find(job_id)
+        response = Zuora::HttpClient.get(find_job_url(job_id), headers: auth_header)
+        handle_response(response)
+      end
+
+      def query_job_url
+        "#{Zuora.base_url}/query/jobs"
+      end
+
+      def find_job_url(job_id)
+        "#{Zuora.base_url}/query/jobs/#{job_id}"
+      end
+
+    private
+
+      def auth_header
+        {
+          Authorization: "Bearer #{AccessToken.generate}"
+        }
+      end
+
+      def default_params
+        {
+          compression: 'NONE',
+          output: { target: 'S3' },
+          outputFormat: 'CSV'
+        }
+      end
+
+      def handle_response(response)
+        raise Zuora::ErrorHandler::APIError, response unless response.code == 200
+
+        response['data']
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Summary
- Subscription renewal notification is not supported for Evergreen type in Zuora
- So new resource `[Data query job]`(https://www.zuora.com/developer/api-reference/#tag/Data-Queries) added to run SQL query in Zuora
- It uses `Bearer token` for authorization not usual `Basic Auth`
- `Data query` and `Bearer token` applicable only for Subscription renewal notification so we don't have to upgrade Zuora API version.

#### Motivation / Context
https://tradegecko.atlassian.net/browse/SE-177
https://tradegecko.atlassian.net/browse/SE-87

#### Next Best Alternatives
- We could have used Zuora automation addon which is like TG workflow but costs around 20k
- Zuora support bill preview run but we are sending renewal notification only for annual customers whose renewal date is within 60 days. So we are not using this feature which generates preview invoice for all the customers.
- Bill preview run supports batches, but we are using batches for charging customer based on the timezone. Eg. US customers mapped to America batch to collect payment only on day time.

#### Drawbacks and/or Unresolved Questions
- We are not storing `Access token`
- We will generate new Access token for each request, as we are using only 2 API request so it won't be a problem
- In future, if its needed for multiple API calls then we will store it
- We are not increasing the version of this gem.


#### Merging + Deployment Plan + Any follow-ups required
-  `CLIENT_ID` AND `CLIENT_SECRET` credentials should be added in TG app ENV
- TG app PR https://github.com/tradegecko/tradegecko/pull/23642